### PR TITLE
Align onDeferredPurchaseCompleted param name with sandwich (purchaseResult)

### DIFF
--- a/android/src/main/java/io/qonversion/capacitor/QonversionPlugin.kt
+++ b/android/src/main/java/io/qonversion/capacitor/QonversionPlugin.kt
@@ -35,8 +35,8 @@ class QonversionPlugin : Plugin() {
             notifyListeners(EntitlementsUpdatedEvent, entitlements.toJSObject())
         }
 
-        override fun onDeferredPurchaseCompleted(transaction: BridgeData) {
-            notifyListeners(DeferredPurchaseCompletedEvent, transaction.toJSObject())
+        override fun onDeferredPurchaseCompleted(purchaseResult: BridgeData) {
+            notifyListeners(DeferredPurchaseCompletedEvent, purchaseResult.toJSObject())
         }
     }
 


### PR DESCRIPTION
One-line rename of the listener override param `transaction` -> `purchaseResult`, matching qonversion/sandwich-sdk#319 (merged). Without this, the next sandwich bump past 7.9.1 makes Kotlin emit the supertype param-name mismatch warning on every consumer build (the same class of warning reported in qonversion/react-native-sdk#439). react-native-sdk and flutter-sdk already use `purchaseResult` in their overrides.

No behavior change: the only call site is positional inside sandwich, and the event payload is a QPurchaseResult map, so the new name is also semantically correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)