### PR TITLE
chore: deprecate public Offerings API

### DIFF
--- a/src/QonversionApi.ts
+++ b/src/QonversionApi.ts
@@ -69,7 +69,9 @@ export interface QonversionApi {
    *
    * @returns the promise with Qonversion offerings
    *
-   * @see [Offerings](https://qonversion.io/docs/offerings) for more details
+   * @deprecated Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs
+   *
+   * @see [Migrate Offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details
    */
   offerings(): Promise<Offerings | null>;
 

--- a/src/internal/QonversionInternal.ts
+++ b/src/internal/QonversionInternal.ts
@@ -134,6 +134,9 @@ export default class QonversionInternal implements QonversionApi {
     return mappedProducts;
   }
 
+  /**
+   * @deprecated Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs
+   */
   async offerings(): Promise<Offerings | null> {
     let offerings = await QonversionNative.offerings();
     const mappedOfferings = Mapper.convertOfferings(offerings);


### PR DESCRIPTION
## Summary

Offerings are a legacy Qonversion feature that is being sunset in favor of
[Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs).
This PR marks the public Offerings API in the Capacitor plugin as deprecated so
developers get an IDE/compiler hint and a pointer to the migration guide.

## Changes

- Add `@deprecated` JSDoc to the public `offerings()` method on the
  `QonversionApi` interface and its implementation in `QonversionInternal`.
- Replace the old `qonversion.io/docs/offerings` `@see` link with the Remote
  Configs migration guide.

## Notes

- **No behavior changes.** The `offerings()` method continues to work exactly
  as before; this is purely a documentation/deprecation annotation.
- DTOs (`Offerings`, `Offering`) are intentionally left untouched.
- Version and CHANGELOG are intentionally not modified.

## Migration guide

https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs

## Related

- documentation_mintlify#100
- dash-mono#571

🤖 Generated with [Claude Code](https://claude.com/claude-code)
