### PR TITLE
feat: expose invalidateRemoteConfigsCache, bump sandwich to 7.12.0 (DEV-1236)

### DIFF
--- a/QonversionCapacitorPlugin.podspec
+++ b/QonversionCapacitorPlugin.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target  = '14.0'
   s.dependency 'Capacitor'
   s.swift_version = '5.1'
-  s.dependency "QonversionSandwich", "7.11.0"
+  s.dependency "QonversionSandwich", "7.12.0"
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation 'androidx.core:core-ktx:1.13.1'
-    implementation "io.qonversion:sandwich:7.11.0"
+    implementation "io.qonversion:sandwich:7.12.0"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/src/main/java/io/qonversion/capacitor/QonversionPlugin.kt
+++ b/android/src/main/java/io/qonversion/capacitor/QonversionPlugin.kt
@@ -143,6 +143,12 @@ class QonversionPlugin : Plugin() {
     }
 
     @PluginMethod
+    fun invalidateRemoteConfigsCache(call: PluginCall) {
+        qonversionSandwich.invalidateRemoteConfigsCache()
+        call.resolve()
+    }
+
+    @PluginMethod
     fun syncHistoricalData(call: PluginCall) {
         qonversionSandwich.syncHistoricalData()
         call.resolve()

--- a/ios/Sources/QonversionPlugin/QonversionPlugin.swift
+++ b/ios/Sources/QonversionPlugin/QonversionPlugin.swift
@@ -17,6 +17,7 @@ public class QonversionPlugin: CAPPlugin, CAPBridgedPlugin {
     CAPPluginMethod(name: "checkEntitlements", returnType: CAPPluginReturnPromise),
     CAPPluginMethod(name: "remoteConfig", returnType: CAPPluginReturnPromise),
     CAPPluginMethod(name: "remoteConfigList", returnType: CAPPluginReturnPromise),
+    CAPPluginMethod(name: "invalidateRemoteConfigsCache", returnType: CAPPluginReturnPromise),
     CAPPluginMethod(name: "userInfo", returnType: CAPPluginReturnPromise),
     CAPPluginMethod(name: "userProperties", returnType: CAPPluginReturnPromise),
     CAPPluginMethod(name: "forceSendProperties", returnType: CAPPluginReturnPromise),
@@ -241,6 +242,11 @@ public class QonversionPlugin: CAPPlugin, CAPBridgedPlugin {
 
   @objc func collectAdvertisingId(_ call: CAPPluginCall) {
     qonversionSandwich?.collectAdvertisingId()
+    call.resolve()
+  }
+
+  @objc func invalidateRemoteConfigsCache(_ call: CAPPluginCall) {
+    qonversionSandwich?.invalidateRemoteConfigsCache()
     call.resolve()
   }
 

--- a/src/QonversionApi.ts
+++ b/src/QonversionApi.ts
@@ -162,6 +162,24 @@ export interface QonversionApi {
   remoteConfigListForContextKeys(contextKeys: Array<string>, includeEmptyContextKey: boolean): Promise<RemoteConfigList>
 
   /**
+   * Invalidates the cache of remote configs so the next {@link remoteConfig} or
+   * {@link remoteConfigList} call fetches a fresh targeting evaluation from the
+   * server instead of returning the cached copy.
+   *
+   * This method performs no network request itself — it only marks the cached
+   * values as stale. An in-flight remoteConfig load is re-issued once so its
+   * waiting calls receive a fresh evaluation; an in-flight remoteConfigList
+   * completes with the evaluation it started with.
+   *
+   * Call it when the targeting inputs changed and you need the change reflected
+   * immediately, for example after setting a batch of user properties your
+   * remote config targeting depends on. You do NOT need to call it after
+   * {@link identify} — the SDK invalidates the cache on identity changes
+   * automatically. Call it after {@link initialize}.
+   */
+  invalidateRemoteConfigsCache(): void;
+
+  /**
    * This function should be used for the test purposes only. Do not forget to delete the usage of this function before the release.
    * Use this function to attach the user to the experiment.
    * @param experimentId identifier of the experiment

--- a/src/QonversionApi.ts
+++ b/src/QonversionApi.ts
@@ -175,7 +175,14 @@ export interface QonversionApi {
    * immediately, for example after setting a batch of user properties your
    * remote config targeting depends on. You do NOT need to call it after
    * {@link identify} — the SDK invalidates the cache on identity changes
-   * automatically. Call it after {@link initialize}.
+   * automatically.
+   *
+   * If the re-issued load fails, the previously received evaluation is
+   * delivered instead of an error — the call never degrades below the
+   * pre-invalidation result.
+   *
+   * Call it after {@link Qonversion.initialize}: calling before initialization
+   * throws on Android and does nothing on iOS.
    */
   invalidateRemoteConfigsCache(): void;
 

--- a/src/QonversionNativePlugin.ts
+++ b/src/QonversionNativePlugin.ts
@@ -23,8 +23,6 @@ export interface QonversionNativePlugin {
 
   syncHistoricalData(): void;
 
-  invalidateRemoteConfigsCache(): void;
-
   syncStoreKit2Purchases(): void;
 
   checkEntitlements(): Promise<Record<string, QEntitlement> | null | undefined>;
@@ -63,6 +61,8 @@ export interface QonversionNativePlugin {
   remoteConfig(params: {contextKey: string | undefined}): Promise<QRemoteConfig>;
 
   remoteConfigList(params?: {contextKeys: string[], includeEmptyContextKey: boolean}): Promise<QRemoteConfigList>;
+
+  invalidateRemoteConfigsCache(): void;
 
   attachUserToExperiment(params: {experimentId: string, groupId: string}): Promise<void>;
 

--- a/src/QonversionNativePlugin.ts
+++ b/src/QonversionNativePlugin.ts
@@ -23,6 +23,8 @@ export interface QonversionNativePlugin {
 
   syncHistoricalData(): void;
 
+  invalidateRemoteConfigsCache(): void;
+
   syncStoreKit2Purchases(): void;
 
   checkEntitlements(): Promise<Record<string, QEntitlement> | null | undefined>;

--- a/src/internal/QonversionInternal.ts
+++ b/src/internal/QonversionInternal.ts
@@ -64,6 +64,10 @@ export default class QonversionInternal implements QonversionApi {
     QonversionNative.syncHistoricalData();
   }
 
+  invalidateRemoteConfigsCache() {
+    QonversionNative.invalidateRemoteConfigsCache();
+  }
+
   syncStoreKit2Purchases() {
     if (isIos()) {
       QonversionNative.syncStoreKit2Purchases();

--- a/src/internal/QonversionInternal.ts
+++ b/src/internal/QonversionInternal.ts
@@ -64,10 +64,6 @@ export default class QonversionInternal implements QonversionApi {
     QonversionNative.syncHistoricalData();
   }
 
-  invalidateRemoteConfigsCache() {
-    QonversionNative.invalidateRemoteConfigsCache();
-  }
-
   syncStoreKit2Purchases() {
     if (isIos()) {
       QonversionNative.syncStoreKit2Purchases();
@@ -303,6 +299,10 @@ export default class QonversionInternal implements QonversionApi {
     const mappedRemoteConfigList: RemoteConfigList = Mapper.convertRemoteConfigList(remoteConfigList);
 
     return mappedRemoteConfigList;
+  }
+
+  invalidateRemoteConfigsCache() {
+    QonversionNative.invalidateRemoteConfigsCache();
   }
 
   async attachUserToExperiment(experimentId: string, groupId: string): Promise<void> {

--- a/src/internal/web.ts
+++ b/src/internal/web.ts
@@ -136,6 +136,10 @@ export class QonversionWeb extends WebPlugin implements QonversionNativePlugin {
         throw this.unimplemented("not implemented yet");
     }
 
+    invalidateRemoteConfigsCache(): void {
+        throw this.unimplemented("not implemented yet");
+    }
+
     syncPurchases(): void {
         throw this.unimplemented("not implemented yet");
     }

--- a/src/internal/web.ts
+++ b/src/internal/web.ts
@@ -116,6 +116,10 @@ export class QonversionWeb extends WebPlugin implements QonversionNativePlugin {
         throw this.unimplemented("not implemented yet");
     }
 
+    invalidateRemoteConfigsCache(): void {
+        throw this.unimplemented("not implemented yet");
+    }
+
     restore(): Promise<Record<string, QEntitlement> | null | undefined> {
         throw this.unimplemented("not implemented yet");
     }
@@ -133,10 +137,6 @@ export class QonversionWeb extends WebPlugin implements QonversionNativePlugin {
     }
 
     syncHistoricalData(): void {
-        throw this.unimplemented("not implemented yet");
-    }
-
-    invalidateRemoteConfigsCache(): void {
         throw this.unimplemented("not implemented yet");
     }
 


### PR DESCRIPTION
B4 exposure from the Remote Config targeting review ([dash-mono PR #674](https://github.com/qonversion/dash-mono/pull/674)). Linear: [DEV-1236](https://linear.app/qonversion/issue/DEV-1236). Exposes the new cache invalidation API released in [android-sdk 9.7.0](https://github.com/qonversion/android-sdk/releases/tag/sdk%2F9.7.0) / [qonversion-ios-sdk 6.14.0](https://github.com/qonversion/qonversion-ios-sdk/releases/tag/6.14.0), bridged by [sandwich 7.12.0](https://github.com/qonversion/sandwich-sdk/releases/tag/7.12.0).

## What changed

1. **Sandwich pinned to 7.12.0** (Android + iOS). Note: the sandwich pod pins `Qonversion` exactly, so apps that also declare the native `Qonversion` pod directly must move to 6.14.0.
2. **New public API `invalidateRemoteConfigsCache`** — a void no-callback pass-through to the native method. It performs no network request; it marks the remote configs cache stale so the next `remoteConfig` / `remoteConfigList` call fetches a fresh targeting evaluation. An in-flight `remoteConfig` load is re-issued once so its waiting calls receive a fresh evaluation (degrading to the superseded one if the retry fails); an in-flight `remoteConfigList` completes with the evaluation it started with. You do NOT need to call it after `identify` — the SDK invalidates on identity changes automatically. Call it after initialization (calling before initialization crashes on Android and no-ops on iOS, same as the other void bridges).

## Release notes for this wrapper (minor bump)
- Source-breaking note for the release: `QonversionApi` and `QonversionNativePlugin` gained a new required member — custom implementations and hand-written mocks must add `invalidateRemoteConfigsCache`.


- New: `invalidateRemoteConfigsCache` — invalidate the remote configs cache on demand (e.g. after setting a batch of user properties your targeting depends on).
- Native SDKs updated: Android 9.7.0, iOS 6.14.0 — automatic remote configs cache invalidation on same-uid `identify`, never-worse re-issue of superseded in-flight loads, uncached bundled fallbacks with rate-limit tolerance (remote configs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4V5cx2SMU4VrfPntwfKJ9
