### PR TITLE
Release 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qonversion/capacitor-plugin",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Qonversion provides full in-app purchases infrastructure, so you do not need to build your own server for receipt validation. Implement in-app subscriptions, validate user receipts, check subscription status, and provide access to your app features and content using our StoreKit wrapper and Google Play Billing wrapper.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/src/internal/QonversionInternal.ts
+++ b/src/internal/QonversionInternal.ts
@@ -22,7 +22,7 @@ import {PurchaseOptionsBuilder} from '../dto/PurchaseOptionsBuilder';
 import {SKProductDiscount} from '../dto/storeProducts/SKProductDiscount';
 import {PromotionalOffer} from '../dto/PromotionalOffer';
 
-export const sdkVersion = "1.7.0";
+export const sdkVersion = "1.8.0";
 export const sdkSource = "capacitor";
 
 const entitlementsUpdatedEvent = 'entitlementsUpdatedEvent';


### PR DESCRIPTION
Release PR

<!-- release-notes:start -->
## New

* New public API `invalidateRemoteConfigsCache` — invalidates the remote configs cache so the next `remoteConfig` / `remoteConfigList` call fetches a fresh targeting evaluation. It performs no network request itself; call it when the targeting inputs changed and you need the change reflected immediately, for example after setting a batch of user properties your targeting depends on. You do not need to call it after `identify` — the SDK invalidates the cache on identity changes automatically (#78).

## Improvements & fixes

* Native SDKs updated via QonversionSandwich 7.12.0: [Android 9.7.0](https://github.com/qonversion/android-sdk/releases/tag/sdk%2F9.7.0) and [iOS 6.14.0](https://github.com/qonversion/qonversion-ios-sdk/releases/tag/6.14.0) — automatic remote configs cache invalidation on same-uid `identify`, never-worse re-issue of superseded in-flight remote config loads, uncached bundled fallbacks with rate-limit tolerance (remote configs only) (#78).

## Breaking notes

* `QonversionApi` and `QonversionNativePlugin` gained a new required member — custom implementations and hand-written mocks must add `invalidateRemoteConfigsCache`.
* The sandwich pod pins the native `Qonversion` pod exactly: apps that also declare `Qonversion` directly must move to 6.14.0.
<!-- release-notes:end -->
