### PR TITLE
feat: expose frozen Remote Config assignments

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,10 +8,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         name: Checkout
         
       - uses: borales/actions-yarn@v3.0.0
         name: Validation
         with:
           cmd: install
+
+      - name: Verify frozen assignment mapping
+        run: yarn test src/internal/__tests__/Mapper.test.ts --runInBand

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,5 +34,8 @@ jobs:
           yarn
           yarn build
 
+      - name: Verify frozen assignment mapping
+        run: yarn test src/internal/__tests__/Mapper.test.ts --runInBand
+
       - name: Publish to npm
         run: npm publish

--- a/QonversionCapacitorPlugin.podspec
+++ b/QonversionCapacitorPlugin.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target  = '14.0'
   s.dependency 'Capacitor'
   s.swift_version = '5.1'
-  s.dependency "QonversionSandwich", "7.12.0"
+  s.dependency "QonversionSandwich", "7.13.0"
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation 'androidx.core:core-ktx:1.13.1'
-    implementation "io.qonversion:sandwich:7.12.0"
+    implementation "io.qonversion:sandwich:7.13.0"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/src/dto/enums.ts
+++ b/src/dto/enums.ts
@@ -257,6 +257,7 @@ export enum RemoteConfigurationAssignmentType {
   UNKNOWN = "unknown",
   AUTO = "auto",
   MANUAL = "manual",
+  FROZEN = "frozen",
 }
 
 export enum ActionType {

--- a/src/internal/Mapper.ts
+++ b/src/internal/Mapper.ts
@@ -1071,6 +1071,8 @@ class Mapper {
         return RemoteConfigurationAssignmentType.AUTO;
       case "manual":
         return RemoteConfigurationAssignmentType.MANUAL;
+      case "frozen":
+        return RemoteConfigurationAssignmentType.FROZEN;
       default:
         return RemoteConfigurationAssignmentType.UNKNOWN;
     }

--- a/src/internal/__tests__/Mapper.test.ts
+++ b/src/internal/__tests__/Mapper.test.ts
@@ -1,0 +1,13 @@
+import {RemoteConfigurationAssignmentType} from '../../dto/enums';
+import Mapper from '../Mapper';
+
+describe('remote configuration assignment provenance', () => {
+  it('preserves frozen and keeps unknown values fail-safe', () => {
+    expect(Mapper.convertRemoteConfigurationAssignmentType('frozen')).toBe(
+      RemoteConfigurationAssignmentType.FROZEN,
+    );
+    expect(Mapper.convertRemoteConfigurationAssignmentType('future')).toBe(
+      RemoteConfigurationAssignmentType.UNKNOWN,
+    );
+  });
+});


### PR DESCRIPTION
Adds `frozen` assignment provenance to Capacitor and pins Sandwich 7.13.0. Draft/stacked: merge only after qonversion/sandwich-sdk#357 is published. The existing Frozen/Unknown mapper contract now runs in pull-request CI and before package publication. Jest mapper tests and the TypeScript build pass locally.
